### PR TITLE
Fix device/resource discovery

### DIFF
--- a/routes/oicRoutes.js
+++ b/routes/oicRoutes.js
@@ -47,11 +47,14 @@ var routes = function(DEV) {
       });
 
       console.log("GET %s", req.originalUrl);
+
+      discoveredDevices.length = 0;
+      DEV.client.addEventListener(DEVICE_FOUND_EVENT, onDeviceFound);
+
+      console.log("Discovering devices for %d seconds.", timeoutValue/1000);
       DEV.client.findDevices().then(function() {
         // TODO: should we send in-progress back to http-client
-        console.log("Discovering devices for %d seconds.", timeoutValue/1000);
-        discoveredDevices.length = 0;
-        DEV.client.addEventListener(DEVICE_FOUND_EVENT, onDeviceFound);
+        console.log("findDevices() successful");
       })
       .catch(function(e) {
         console.log("Error: " + e.message);
@@ -68,11 +71,14 @@ var routes = function(DEV) {
       });
 
       console.log("GET %s", req.originalUrl);
+
+      discoveredResources.length = 0;
+      DEV.client.addEventListener(RESOURCE_FOUND_EVENT, onResourceFound);
+
+      console.log("Discovering resources for %d seconds.", timeoutValue/1000);
       DEV.client.findResources().then(function() {
         // TODO: should we send in-progress back to http-client
-        console.log("Discovering resources for %d seconds.", timeoutValue/1000);
-        discoveredResources.length = 0;
-        DEV.client.addEventListener(RESOURCE_FOUND_EVENT, onResourceFound);
+        console.log("findResources() successful");
       })
       .catch(function(e) {
         console.log(e);


### PR DESCRIPTION
Adding event listeners inside the promise resolve can cause an
issue in discovering the first resource/device, since the promises
are resolved upon first response to a discovery request.

To fix the issue, add event listeners outside the promise resolve.